### PR TITLE
Add filter to stop importing after a certain count, replace Twitter-shortened links with full version

### DIFF
--- a/importers/keyring-importer-twitter.php
+++ b/importers/keyring-importer-twitter.php
@@ -38,6 +38,17 @@ class Keyring_Twitter_Importer extends Keyring_Importer_Base {
 				return $reprocessors;
 			} );
 		}
+
+		// Fix shortened links in Twitter importer
+		add_filter( 'keyring_importer_reprocessors', function( $reprocessors ) {
+			$reprocessors[ 'twitter-shortlinks' ] = array(
+				'label'       => __( 'Expand shortened links in Tweets', 'keyring' ),
+				'description' => __( 'Old tweets preserved the Twitter link shortener version of URLs. The importer handles them correctly now, and this will reprocess old data to use the full URL.', 'keyring' ),
+				'callback'    => array( $this, 'reprocess_shortened_links' ),
+				'service'     => $this->taxonomy->slug,
+			);
+			return $reprocessors;
+		} );
 	}
 
 	function custom_options() {
@@ -216,6 +227,19 @@ class Keyring_Twitter_Importer extends Keyring_Importer_Base {
 			// Better content for retweets
 			if ( ! empty( $post->retweeted_status ) ) {
 				$post_content = $post->retweeted_status->text;
+			}
+
+			// Replace any shortened URLs with the real thing
+			if ( ! empty( $post->entities->urls ) ) {
+				foreach ( $post->entities->urls as $url ) {
+					$post_content = str_replace( $url->url, esc_url( $url->expanded_url ), $post_content );
+				}
+			}
+			// Include any media URLs
+			if ( ! empty( $post->extended_entities->media ) ) {
+				foreach ( $post->extended_entities->media as $image ) {
+					$post_content = str_replace( $image->url, esc_url( $image->expanded_url ), $post_content );
+				}
 			}
 
 			// Clean up post content for insertion
@@ -460,6 +484,53 @@ class Keyring_Twitter_Importer extends Keyring_Importer_Base {
 		wp_update_post( $post_data );
 
 		return Keyring_Importer_Reprocessor::PROCESS_SUCCESS;
+	}
+
+	/*
+	 * Fix shortened links
+	 */
+	function reprocess_shortened_links( $post ) {
+		// Get raw data
+		$raw = get_post_meta( $post->ID, 'raw_import_data', true );
+		if ( ! $raw ) {
+			return Keyring_Importer_Reprocessor::PROCESS_SKIPPED;
+		}
+
+		// Decode it, and bail if that fails for some reason
+		$raw = json_decode( $raw );
+		if ( null === $raw ) {
+			return Keyring_Importer_Reprocessor::PROCESS_FAILED;
+		}
+
+		// Don't bother if there are no URLs to replace
+		if ( empty( $raw->entities->urls ) && empty( $raw->extended_entities->media ) ) {
+			return Keyring_Importer_Reprocessor::PROCESS_SKIPPED;
+		}
+
+		// We start with the current post content instead of the original raw tweet,
+		// since the import does some adjusting and polishing we don't want to lose.
+		$post_content = $post->post_content;
+
+		// Replace any URLs
+		if ( ! empty( $raw->entities->urls ) ) {
+			foreach ( $raw->entities->urls as $url ) {
+				$post_content = str_replace( $url->url, esc_url( $url->expanded_url ), $post_content );
+			}
+		}
+		// Include any media URLs
+		if ( ! empty( $raw->extended_entities->media ) ) {
+			foreach ( $raw->extended_entities->media as $image ) {
+				$post_content = str_replace( $image->url, esc_url( $image->expanded_url ), $post_content );
+			}
+		}
+
+		// Update the post with the fixed content
+		$post_data = get_post( $post->ID );
+		$post_data->post_content = $post_content;
+		wp_update_post( $post_data );
+
+		return Keyring_Importer_Reprocessor::PROCESS_SUCCESS;
+
 	}
 }
 

--- a/keyring-importers.php
+++ b/keyring-importers.php
@@ -648,6 +648,8 @@ abstract class Keyring_Importer_Base {
 		do_action( 'import_start' );
 		$num = 0;
 		$this->header();
+		$stop_after_imported_count = apply_filters( 'keyring_importer_stop_after_imported_count', null ); 
+
 		echo '<p>' . __( 'Importing Posts...' ) . '</p>';
 		echo '<ol>';
 		while ( ! $this->finished && $num < static::REQUESTS_PER_LOAD ) {
@@ -675,6 +677,11 @@ abstract class Keyring_Importer_Base {
 
 			// Local (per-page-load) counter
 			$num++;
+
+			if ( isset( $stop_after_imported_count ) && ( $this->get_option( 'imported' ) >= $stop_after_imported_count ) ) {
+				$this->finished = true;
+			}
+
 		}
 		echo '</ol>';
 		$this->footer();


### PR DESCRIPTION
As I'm testing some tweaks to the import of my Twitter feed (and hopefully submitting some other PRs here), I wanted a way to do a limited import for faster debugging. This commit adds a WordPress filter `keyring_importer_stop_after_imported_count` that allows one to specify an import threshold after which (but not necessarily right at) the import will end. Setting it to something low like 10 means that the import would likely conclude after the first request, about 75 tweets in my case.

There may be a better way, or a better place to put this, but hopefully something like it will be useful to others.