### PR TITLE
Add more Strava types & fix polylines

### DIFF
--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -337,7 +337,7 @@ function Keyring_Strava_Importer() {
 
 					// Store the encoded polyline; will require decoding to map it
 					if ( $geo ) {
-						add_post_meta( $post_id, 'geo_polyline_encoded', $geo );
+						add_post_meta( $post_id, 'geo_polyline_encoded', wp_slash( wp_json_encode( $geo ) ) );
 						add_post_meta( $post_id, 'geo_public', ( $private ? '0' : '1') ); // Hide geo if it's a private activity
 					}
 

--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -179,6 +179,24 @@ function Keyring_Strava_Importer() {
 				// TODO: add heartrate, but conditionally on "has_heartrate":true in the API response.
 				if ( ! empty( $post->distance ) ) {
 					switch ( $post->type ) {
+						case 'Swim':
+							$post_content = sprintf(
+								// Translators: Swam [distance] in [duration].
+								__( 'Swam %1$s in %2$s.' ),
+								$this->format_distance( $post->distance ),
+								$this->format_duration( $post->moving_time )
+							);
+							break;
+
+						case 'Walk':
+							$post_content = sprintf(
+								// Translators: Walked [distance] in [duration].
+								__( 'Walked %1$s in %2$s.' ),
+								$this->format_distance( $post->distance ),
+								$this->format_duration( $post->moving_time )
+							);
+							break;
+
 						case 'Hike':
 							$post_content = sprintf(
 								// Translators: Hiked [distance] in [duration].

--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -257,6 +257,7 @@ function Keyring_Strava_Importer() {
 
 				$strava_id        = $post->id;
 				$strava_permalink = 'https://www.strava.com/activities/' . $post->id;
+				$strava_type = $post->type;
 
 				// Grab an encoded/compressed polyline of the GPS data if available.
 				$geo = '';
@@ -278,6 +279,7 @@ function Keyring_Strava_Importer() {
 					'tags',
 					'strava_raw',
 					'strava_permalink',
+					'strava_type',
 					'strava_id',
 					'geo',
 					'private'
@@ -331,6 +333,7 @@ function Keyring_Strava_Importer() {
 
 					add_post_meta( $post_id, 'strava_id', $strava_id );
 					add_post_meta( $post_id, 'strava_permalink', $strava_permalink );
+					add_post_meta( $post_id, 'strava_type', $strava_type );
 
 					// Store the encoded polyline; will require decoding to map it
 					if ( $geo ) {

--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -345,7 +345,7 @@ function Keyring_Strava_Importer() {
 					add_post_meta( $post_id, 'raw_import_data', wp_slash( wp_json_encode( $strava_raw ) ) );
 					$imported++;
 
-					// A potentially useful action to hoook into for further processing.
+					// A potentially useful action to hook into for further processing.
 					do_action( 'keyring_post_imported', $post_id, static::SLUG, $post );
 				}
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,8 @@ You can potentially [write your own importers](https://github.com/cfinke/Keyring
 
 = Strava =
 * Activities are imported as new Posts.
-* GPS data is stored as an encoded polyline if available.
+* Activity type is stored as post meta for easier querying.
+* GPS data is stored as an encoded polyline if available. [https://github.com/emcconville/google-map-polyline-encoding-tool](Google Maps Polyline Encoding Tool) has been tested to work well with the data.
 * Stores raw and summary data for further processing.
 * Currently does NOT download any media or support People & Places.
 


### PR DESCRIPTION
In this PR, I've added `Swim` and `Walk` types and I've also added saving this type into post meta field `strava_type` (used string directly from Strava so example values are `Walk`, `Swim`, `Ride`, …)

I've also noticed that polylines saved by the initial Strava importer are corrupted. Unfortunately the encoding uses slashes as proper characters and they were getting stripped. Other places online recommended using JSON stringification as a storage/transfer medium for the encoded polyline so I've implemented it that way (`wp_slash( wp_json_encode ( $polyline ) )`). 

I've added a reprocessor to fix the polylines and added a mention of a polyline library that worked for me with the data.