### PR TITLE
Set a (instagram) post as private using a tag

### DIFF
--- a/importers/keyring-importer-instagram.php
+++ b/importers/keyring-importer-instagram.php
@@ -222,8 +222,12 @@ class Keyring_Instagram_Importer extends Keyring_Importer_Base {
 			}
 
 			// Other bits
+			$status = $this->get_option( 'status', 'publish' );
+			if ( ! empty( $tags ) && is_array( $tags ) && array_search( 'keyringprivate', $tags ) !== false ) {
+				$status = 'private';
+			}
 			$post_author      = $this->get_option( 'author' );
-			$post_status      = $this->get_option( 'status', 'publish' );
+			$post_status      = $status;
 			$instagram_id     = $post->id;
 			$instagram_url    = $post->link;
 			$instagram_img    = $post->images->standard_resolution->url;

--- a/readme.txt
+++ b/readme.txt
@@ -77,8 +77,10 @@ You can potentially [write your own importers](https://github.com/cfinke/Keyring
 = Instagram =
 * Each photo on your [Instagram](https://instagram.com/) account is downloaded and imported into your Media Library.
 * For every photo, a Post is created and published, containing that one image (and it is attached within WordPress).
+* You can label a Post as private by using the tag #keyringprivate in the original photo
 * Posts are marked with the 'image' Post Format.
 * The name of the filter used is stored as instagram_filter, the URL to the photo page is stored as instagram_url.
+
 
 = Instapaper =
 * Imports your *Archived* links and creates a post for each of them (with post format of Link).

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,6 @@ You can potentially [write your own importers](https://github.com/cfinke/Keyring
 * Posts are marked with the 'image' Post Format.
 * The name of the filter used is stored as instagram_filter, the URL to the photo page is stored as instagram_url.
 
-
 = Instapaper =
 * Imports your *Archived* links and creates a post for each of them (with post format of Link).
 * Uses the title from the document in Instapaper, if there is a description associated then it uses that as well.


### PR DESCRIPTION
I don't know if this makes sense for anyone else, but since my Instagram account is private, I would like to mark some post (but not all) as private when I import them to my site.

This PR adds a check to see if you have tagged your Instagram post with #keyringprivate, and if you do, the new post is marked as private, no matter your import settings. 