### PR TITLE
Suggest the default category, not first

### DIFF
--- a/keyring-importers.php
+++ b/keyring-importers.php
@@ -521,7 +521,7 @@ abstract class Keyring_Importer_Base {
 					<td>
 						<select name="category" id="category">
 						<?php
-							$prev_cat = $this->get_option( 'category' );
+							$prev_cat = $this->get_option( 'category', get_option( 'default_category' ) );
 							$categories = get_categories( array( 'hide_empty' => 0 ) );
 							foreach ( $categories as $cat ) {
 								printf( '<option value="%s"' . selected( $prev_cat == $cat->term_id ) . '>%s</option>', $cat->term_id, $cat->name );


### PR DESCRIPTION
Tiny tweak. I've noticed the UI is preselecting the first category in the list, which might not be the default one for new posts. I've made it read the default from options. This is user-configurable in `options-writing.php`