### PR TITLE
Implement Strava post status configuration

### DIFF
--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -14,10 +14,10 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 	const KEYRING_SERVICE   = 'Keyring_Service_Strava';    // Full class name of the Keyring_Service this importer requires.
 	const REQUESTS_PER_LOAD = 1; // How many remote requests should be made before reloading the page?
 	const NUM_PER_LOAD      = 30; // How many activities per API request? We'll use Strava's default of 30.
-	
+
 	function __construct() {
 		parent::__construct();
-		
+
 		// Fix problem with polyline escaping in postmeta
 		add_filter( 'keyring_importer_reprocessors', function( $reprocessors ) {
 			$reprocessors[ 'strava-geo-polyline' ] = array(
@@ -122,7 +122,7 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 	/**
 	 * Helper function to format seconds to minutes and hours
 	 * Anything less than 1 hour is shown in minutes, otherwise hours + minutes
-     * 
+     *
 	 * @param number $num is a time value in seconds
 	 */
 	function format_duration( $num ) {
@@ -246,7 +246,6 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 			$post_author = $this->get_option( 'author' );
 
 			// Set post status from import options, default to published unless set to private on Strava.
-			// @todo Currently this won't work because you need a token with scope=activity:read_all to get private activities. Will need to modify or filter the Strava Service file for that.
 			$private = $post->private;
 			$post_status = $this->get_option( 'status', 'publish' );
 			if ( $private ) {
@@ -375,11 +374,11 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 		if ( ! empty( $raw->map ) && ! empty( $raw->map->summary_polyline ) ) {
 			$geo = $raw->map->summary_polyline;
 		}
-		
+
 		if ( empty( $geo ) ) {
 			return Keyring_Importer_Reprocessor::PROCESS_SKIPPED;
 		}
-		
+
 		update_post_meta( $post->ID, 'geo_polyline_encoded', wp_slash( $geo ) );
 
 		return Keyring_Importer_Reprocessor::PROCESS_SUCCESS;

--- a/importers/keyring-importer-strava.php
+++ b/importers/keyring-importer-strava.php
@@ -35,6 +35,10 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 	 */
 	function handle_request_options() {
 		// Validate options and store them so they can be used in auto-imports.
+		if ( empty( $_POST['status'] ) || ! in_array( $_POST['status'], array( 'publish', 'pending', 'draft', 'private' ) ) ) {
+			$this->error( __( "Make sure you select a valid post status to assign to your imported posts.", 'keyring' ) );
+		}
+
 		if ( empty( $_POST['category'] ) || ! ctype_digit( $_POST['category'] ) ) {
 			$this->error( __( 'Make sure you select a valid category to import your activities into.', 'keyring' ) );
 		}
@@ -54,6 +58,7 @@ class Keyring_Strava_Importer extends Keyring_Importer_Base {
 			$this->step = 'options';
 		} else {
 			$this->set_option( array(
+				'status'      => (string) $_POST['status'],
 				'category'    => (int) $_POST['category'],
 				'tags'        => explode( ',', $_POST['tags'] ),
 				'author'      => (int) $_POST['author'],


### PR DESCRIPTION
Strava was completely ignoring the value from the status dropdown and so everything used the default, `publish` status.

I've updated it to do the same as other services — validate and store `$_POST['status']` in `handle_request_options`, as introduced in https://github.com/beaulebens/keyring-social-importers/commit/a8c0ea12d98dbf7984983dd983df0690d6724781.

The post saving logic was already counting with the option so we should be all good there. Additionally, #33 seems to no longer be an issue. Keyring uses the right scope (https://github.com/beaulebens/keyring/commit/4a0f839c72c866502c9a0a121c32e2eaaf8abc8f) and the handling of the `private` property from Strava API is also in place:

https://github.com/beaulebens/keyring-social-importers/blob/6e2ec5d2dd067747e4051d10afacdc6729769ad1/importers/keyring-importer-strava.php#L250-L254

I've removed the comment to reflect that.