### PR TITLE
Avoid a countable error

### DIFF
--- a/importers/keyring-importer-tripit.php
+++ b/importers/keyring-importer-tripit.php
@@ -122,12 +122,11 @@ class Keyring_TripIt_Importer extends Keyring_Importer_Base {
 
 			$prev_end = 0;
 			$post_title = '';
+			// TripIt returns a single-segment trip as an object, ugh!
+			if ( is_object( $trip->Segment ) ) {
+				$trip->Segment = array( $trip->Segment );
+			}
 			for ( $s = 0; $s < count( $trip->Segment ); $s++ ) {
-				// TripIt returns a single-segment trip as an object, ugh!
-				if ( is_object( $trip->Segment ) ) {
-					$trip->Segment = array( $trip->Segment );
-				}
-
 				$segment = $trip->Segment[$s];
 				$this_post = array();
 


### PR DESCRIPTION
```
[27-May-2024 22:10:13 UTC] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, stdClass given in /srv/www/master/html/wp-content/plugins/keyring-social-importers/importers/keyring-importer-tripit.php:125
Stack trace:
#0 /srv/www/html/wp-content/plugins/keyring-social-importers/keyring-importers.php(681): Keyring_TripIt_Importer->extract_posts_from_data()
#1 /srv/www/html/wp-content/plugins/keyring-social-importers/keyring-importers.php(637): Keyring_Importer_Base->import()
#2 /srv/www/html/wp-content/plugins/keyring-social-importers/keyring-importers.php(323): Keyring_Importer_Base->do_import()
#3 /srv/www/html/wp-admin/admin.php(364): Keyring_Importer_Base->dispatch()
#4 {main}
```